### PR TITLE
Feat: add fluid typographic mixins

### DIFF
--- a/src/scss/globals/_typography.scss
+++ b/src/scss/globals/_typography.scss
@@ -1,8 +1,15 @@
 @use "/src/scss/util/" as u;
+@use "/src/scss/util/_fluid-sizing" as fluid;
+@use "/src/scss/util/_get-typographic-values" as font;
 
 :root {
 	--sans-serif: system-ui, Avenir, Helvetica, Arial, sans-serif;
 	--serif: serif;
+
+  --fw-light: 300;
+  --fw-regular: 400;
+  --fw-medium: 500;
+  --fw-bold: 700;
 
 	font-style: normal;
 	font-weight: 400;
@@ -21,8 +28,59 @@ body {
 }
 
 h1 {
-	font-size: 3.2em;
-	line-height: 1.1;
+  @include fluid.typography(7, 9);
+  font-weight: var(--fw-medium)
+}
+
+h2 {
+  @include fluid.typography(6, 8);
+  font-weight: var(--fw-medium)
+}
+
+h3 {
+  @include fluid.typography(5, 7);
+  font-weight: var(--fw-medium)
+}
+
+h4 {
+  @include fluid.typography(4, 6);
+  font-weight: var(--fw-medium)
+}
+
+h5 {
+  @include fluid.typography(3, 5);
+  font-weight: var(--fw-medium)
+}
+
+h6 {
+  @include fluid.typography(3, 4);
+  font-weight: var(--fw-medium)
+}
+
+a,
+blockquote,
+button,
+code,
+em,
+figcaption,
+p,
+pre,
+q,
+span,
+strong {
+  @include fluid.typography(2, 3);
+
+  &.small {
+    @include fluid.typography(1, 2);
+  }
+  
+  &.large {
+    @include fluid.typography(3, 4);
+  }
+}
+
+small {
+  @include fluid.typography(1, 2);
 }
 
 a {

--- a/src/scss/util/_breakpoints.scss
+++ b/src/scss/util/_breakpoints.scss
@@ -1,19 +1,19 @@
 @use "sass:map";
-@use "functions" as f;
+@use "unit-converters" as unit;
 
 $breakpoints-up: (
-	"medium": f.em(700),
-	"large": f.em(900),
-	"xlarge": f.em(1100),
-	"xxlarge": f.em(1440),
+	"medium": unit.em(700),
+	"large": unit.em(900),
+	"xlarge": unit.em(1100),
+	"xxlarge": unit.em(1440),
 );
 
 $breakpoints-down: (
-	"xsmall": f.em(452.98),
-	"small": f.em(699.98),
-	"medium": f.em(899.98),
-	"large": f.em(1099.98),
-	"xlarge": f.em(1439.98),
+	"xsmall": unit.em(452.98),
+	"small": unit.em(699.98),
+	"medium": unit.em(899.98),
+	"large": unit.em(1099.98),
+	"xlarge": unit.em(1439.98),
 );
 
 @mixin breakpoint($size) {

--- a/src/scss/util/_fluid-sizing.scss
+++ b/src/scss/util/_fluid-sizing.scss
@@ -1,0 +1,80 @@
+@use "sass:math";
+@use "unit-converters" as unit;
+@use "/src/scss/util/_get-typographic-values" as font;
+
+@mixin _validate-inputs($min-val, $max-val, $min-vw, $max-vw, $property-name) {
+	@if unit($min-val) != "" {
+		@error "#{$property-name}() expects unitless numbers for #{$property-name} values, received '#{$min-val}' with unit '#{unit($min-val)}'. Provide numbers only, in px.";
+	}
+	@if unit($max-val) != "" {
+		@error "#{$property-name}() expects unitless numbers for #{$property-name} values, received '#{$max-val}' with unit '#{unit($max-val)}'. Provide numbers only, in px.";
+	}
+	@if unit($min-vw) != "" {
+		@error "#{$property-name}() expects unitless numbers for min-vw, received '#{$min-vw}' with unit '#{unit($min-vw)}'. Provide numbers only, in px.";
+	}
+	@if unit($max-vw) != "" {
+		@error "#{$property-name}() expects unitless numbers for max-vw, received '#{$max-vw}' with unit '#{unit($max-vw)}'. Provide numbers only, in px.";
+	}
+}
+
+@mixin _fluid-property($property, $unit-type, $min-val, $max-val, $min-vw: 360, $max-vw: 1440) {
+	@include _validate-inputs($min-val, $max-val, $min-vw, $max-vw, $property);
+
+	$min-converted: null;
+	$max-converted: null;
+	$min-vw-converted: null;
+	$max-vw-converted: null;
+
+	@if $unit-type == "rem" {
+		$min-converted: unit.rem($min-val);
+		$max-converted: unit.rem($max-val);
+		$min-vw-converted: unit.rem($min-vw);
+		$max-vw-converted: unit.rem($max-vw);
+	} @else if $unit-type == "em" {
+		$min-converted: unit.em($min-val);
+		$max-converted: unit.em($max-val);
+		$min-vw-converted: unit.em($min-vw);
+		$max-vw-converted: unit.em($max-vw);
+	} @else {
+		$min-converted: $min-val * 1px;
+		$max-converted: $max-val * 1px;
+		$min-vw-converted: $min-vw * 1px;
+		$max-vw-converted: $max-vw * 1px;
+	}
+
+	$factor: math.div(1, ($max-vw-converted - $min-vw-converted)) * ($max-converted - $min-converted);
+	$calc-value: null;
+
+	@if $unit-type == "px" {
+		$calc-value: unquote(
+			"calc(#{$min-converted - ($min-vw-converted * $factor)} + #{100vw * $factor})"
+		);
+	} @else {
+		$calc-value: unquote("#{$min-converted - ($min-vw-converted * $factor)} + #{100vw * $factor}");
+	}
+
+	#{$property}: $min-converted;
+	#{$property}: clamp(
+		#{if($min-converted > $max-converted, $max-converted, $min-converted)},
+		#{$calc-value},
+		#{if($min-converted > $max-converted, $min-converted, $max-converted)}
+	);
+}
+
+@mixin font-size($min-fs, $max-fs, $min-vw: 360, $max-vw: 1440) {
+	@include _fluid-property("font-size", "rem", $min-fs, $max-fs, $min-vw, $max-vw);
+}
+
+@mixin leading($min-leading, $max-leading, $min-vw: 360, $max-vw: 1440) {
+	@include _fluid-property("line-height", "px", $min-leading, $max-leading, $min-vw, $max-vw);
+}
+
+@mixin tracking($min-tracking, $max-tracking, $min-vw: 360, $max-vw: 1440) {
+	@include _fluid-property("letter-spacing", "em", $min-tracking, $max-tracking, $min-vw, $max-vw);
+}
+
+@mixin typography($min-step, $max-step, $min-vw: 360, $max-vw: 1440) {
+	@include font-size(font.size($min-step), font.size($max-step), $min-vw, $max-vw);
+	@include leading(font.leading($min-step), font.leading($max-step), $min-vw, $max-vw);
+	@include tracking(font.tracking($min-step), font.tracking($max-step), $min-vw, $max-vw);
+}

--- a/src/scss/util/_get-typographic-values.scss
+++ b/src/scss/util/_get-typographic-values.scss
@@ -1,0 +1,40 @@
+@use "sass:math";
+@use "typographic-scale" as token;
+
+$max-step: length(token.$typographic-scale);
+
+@function get-font-size($step) {
+	@if not map-has-key(token.$typographic-scale, $step) {
+		@error "Typography step '#{$step}' not found in $typographic-scale. Please use a step between 1 and #{$max-step}.";
+	} @else {
+		@return map-get(map-get(token.$typographic-scale, $step), size);
+	}
+}
+
+@function get-leading($step) {
+	@if not map-has-key(token.$typographic-scale, $step) {
+		@error "Typography step '#{$step}' not found in $typographic-scale. Please use a step between 1 and #{$max-step}.";
+	} @else {
+		@return map-get(map-get(token.$typographic-scale, $step), leading);
+	}
+}
+
+@function get-tracking($step) {
+	@if not map-has-key(token.$typographic-scale, $step) {
+		@error "Typography step '#{$step}' not found in $typographic-scale. Please use a step between 1 and #{$max-step}.";
+	} @else {
+		@return map-get(map-get(token.$typographic-scale, $step), tracking);
+	}
+}
+
+@function size($step) {
+	@return get-font-size($step);
+}
+
+@function leading($step) {
+	@return get-leading($step);
+}
+
+@function tracking($step) {
+	@return get-tracking($step);
+}

--- a/src/scss/util/_index.scss
+++ b/src/scss/util/_index.scss
@@ -1,4 +1,7 @@
 @forward "breakpoints";
-@forward "functions";
 @forward "colour-themes";
+@forward "fluid-sizing";
+@forward "get-typographic-values";
 @forward "generate-colour";
+@forward "unit-converters";
+@forward "typographic-scale";

--- a/src/scss/util/_typographic-scale.scss
+++ b/src/scss/util/_typographic-scale.scss
@@ -1,0 +1,47 @@
+$typographic-scale: (
+	1: (
+		size: 12,
+		leading: 16,
+		tracking: 0.0025,
+	),
+	2: (
+		size: 14,
+		leading: 20,
+		tracking: 0,
+	),
+	3: (
+		size: 16,
+		leading: 24,
+		tracking: 0,
+	),
+	4: (
+		size: 18,
+		leading: 26,
+		tracking: -0.0025,
+	),
+	5: (
+		size: 20,
+		leading: 28,
+		tracking: -0.005,
+	),
+	6: (
+		size: 24,
+		leading: 30,
+		tracking: -0.00625,
+	),
+	7: (
+		size: 28,
+		leading: 36,
+		tracking: -0.0075,
+	),
+	8: (
+		size: 35,
+		leading: 40,
+		tracking: -0.01,
+	),
+	9: (
+		size: 60,
+		leading: 60,
+		tracking: -0.025,
+	),
+);

--- a/src/scss/util/_unit-converters.scss
+++ b/src/scss/util/_unit-converters.scss
@@ -2,7 +2,7 @@
 
 @function rem($pixel) {
 	@if math.is-unitless($pixel) {
-		@return math.div($pixel, 16) + rem;
+		@return math.div($pixel, 16) * 1rem;
 	} @else {
 		@error "rem() expects a unitless number, received '#{$pixel}'";
 	}
@@ -10,7 +10,7 @@
 
 @function em($pixel) {
 	@if math.is-unitless($pixel) {
-		@return math.div($pixel, 16) + em;
+		@return math.div($pixel, 16) * 1em;
 	} @else {
 		@error "em() expects a unitless number, received '#{$pixel}'";
 	}


### PR DESCRIPTION
- Rename `_functions.scss` to `_unit-converters.scss`.
- Define typographic properties in steps in `typographic-scale.scss`.
- Create `_get-typographic-values.scss` to retrieve typographic properties from `typographic-scale.scss`.
- Create `_fluid-sizing.scss` to house fluid sizing mixins, currently for `font-size`, `leading` and `tracking`.
- Apply fluid typography properties to most typographic HTML elements in `_typography.scss`.